### PR TITLE
Add Susi Lehtola as a copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright (c) 2018 Susi Lehtola <susi.lehtola@alumni.helsinki.fi>
 Copyright (c) 2020 Morten Piibeleht <morten.piibeleht@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
In addition to just wrapping HelFEM, the package contains work derived from HelFEM too. Those parts of HelFEM (which is generally under GPL) are re-licensed here under MIT with the author's (Susi Lehtola) permission.

cc @susilehtola 